### PR TITLE
Cache Tags

### DIFF
--- a/src/Blade/CacheManager.php
+++ b/src/Blade/CacheManager.php
@@ -17,22 +17,22 @@ class CacheManager implements ManagesCaches
 
     // In CacheManager.php
 
-    public function put($key, $fragment, $ttl = null): string
+    public function put($key, $fragment, int | null $ttl = null, string | array $tags = 'views'): string
     {
         $key = $this->normalizeCacheKey($key);
         if ($ttl) {
-            $this->cache->tags('views')->put($key, $fragment, $ttl);
+            $this->cache->tags($tags)->put($key, $fragment, $ttl);
             return $fragment;
         }
-        return $this->cache->tags('views')->rememberForever($key, function () use ($fragment) {
+        return $this->cache->tags($tags)->rememberForever($key, function () use ($fragment) {
             return $fragment;
         });
     }
 
-    public function has($key): bool
+    public function has($key, $tags = 'views'): bool
     {
         $key = $this->normalizeCacheKey($key);
-        return $this->cache->tags('views')->has($key);
+        return $this->cache->tags($tags)->has($key);
     }
 
     protected function normalizeCacheKey($key)

--- a/src/BladeDirective.php
+++ b/src/BladeDirective.php
@@ -28,7 +28,7 @@ class BladeDirective
         ob_start();
         $this->options = $options;
         try {
-            $this->keys[] = $key = $this->normalizeKey($keyOrModel);
+            $this->keys[] = $key = $this->normalizeKey($keyOrModel); //why is this an array?
             return $this->cache->has($key);
         } catch (Exception $e) {
             // don't allow exceptions to bubble up as they will break the view
@@ -42,7 +42,7 @@ class BladeDirective
         $localKeys = $this->keys;
         foreach ($this->options as $strategy => $value) {
             try {
-                return $this->applyCacheStrategy($strategy, $localKeys, $value);
+                return $this->applyCacheStrategy($strategy, array_pop($localKeys), $value);
             } catch (Exception $e) {
                 Log::error($e->getMessage());
                 // If the strategy failed, we refuse to cache and return the output.
@@ -107,6 +107,7 @@ class BladeDirective
     {
         if (ob_get_level() > 0) {
             return match ($strategy) {
+                'tags' => $this->cache->put($key, ob_get_clean(), null, $value),
                 'ttl' => $this->cache->put($key, ob_get_clean(), $this->normalizeTtl($value)),
                 default => throw new Exception('Unknown strategy: '.$strategy),
             };

--- a/src/Contracts/ManagesCaches.php
+++ b/src/Contracts/ManagesCaches.php
@@ -8,7 +8,7 @@ interface ManagesCaches
 {
     public function __construct(Repository $cache);
 
-    public function put($key, $fragment, $ttl = null): string;
+    public function put($key, $fragment, int | null $ttl = null, string | array $tags = 'views'): string;
 
-    public function has($key): bool;
+    public function has($key, $tags = null): bool;
 }

--- a/tests/BladeDirectiveTest.php
+++ b/tests/BladeDirectiveTest.php
@@ -80,6 +80,32 @@ class BladeDirectiveTest extends TestCase
         );
     }
 
+    public function test_it_handles_a_single_tag()
+    {
+        $directive = $this->createNewCacheDirective();
+        $directive->setUp('my-unique-key', ['tags' => 'tag']);
+        echo "<div>view tag</div>";
+        $directive->tearDown();
+        $options = $directive->getOptions();
+        $this->assertIsArray($options, 'Options should be an array.');
+        $this->assertArrayHasKey('tags', $options, 'Options should contain a tags key.');
+        $this->assertIsString($options['tags'], 'Tag should be a string.');
+        //test that we set the tag
+        $this->assertTrue($this->cacheManager->has('my-unique-key','tag'));
+    }
+
+    public function test_it_handles_multiple_tags()
+    {
+        $directive = $this->createNewCacheDirective();
+        $directive->setUp('my-unique-key', ['tags' => ['tag1','tag2']]);
+        echo "<div>view tags</div>";
+        $directive->tearDown();
+        $options = $directive->getOptions();
+        $this->assertIsArray($options, 'Options should be an array.');
+        $this->assertArrayHasKey('tags', $options, 'Options should contain a tags key.');
+        $this->assertIsArray($options['tags'], 'Tags should be a Array.');
+        $this->assertTrue($this->cacheManager->has('my-unique-key',['tag1','tag2']));
+    }
 
 
     protected function createNewCacheDirective(): BladeDirective


### PR DESCRIPTION
## Description

#### Cache Tags:

Tags related content together, allowing for group invalidation.

```html
@cache('my-unique-key', ['tags' => ['tag1', 'tag2']])
    <div>view fragment</div>
@endcache
```

To manually clear this cache, use:

```php
Cache::tags(['tag1', 'tag2'])->flush();
```

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Related Ticket

[*Link to the Redmine ticket.*](https://projects.it-jonction-lab.io/issues/8636)

## Changes

*List the major changes made in this pull request.*

1. Adds the ability to provide an associative array of tags to group caches to be flushed together

## Testing
1. Will be tested locally
2. Tests will be written

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
