### PR TITLE
Content Versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ By understanding and correctly using cache tags, you can efficiently group, mana
 Always remember to use the exact combination of tags for storing and retrieving cache items, and be aware that invalidating 
 a tag will affect all items that include that tag, even if they have additional tags. 
 
-#### Content Versioning: todo (1% done) 
+#### Content Versioning: done
 
 Uses the version numbers to force cache updates on each release.
 
@@ -478,7 +478,7 @@ Simply providing a string, rather than a model, instructs the package to use `my
 - [x] Manual Invalidation
 - [x] Time-to-Live (TTL)
 - [x] Cache Tags
-- [ ] Content Versioning
+- [x] Content Versioning
 - [ ] Stale-While-Revalidate
 - [ ] Conditional Requests
 - [ ] Event-Driven Invalidation

--- a/src/BladeDirective.php
+++ b/src/BladeDirective.php
@@ -109,6 +109,7 @@ class BladeDirective
             return match ($strategy) {
                 'tags' => $this->cache->put($key, ob_get_clean(), null, $value),
                 'ttl' => $this->cache->put($key, ob_get_clean(), $this->normalizeTtl($value)),
+                'version' => $this->cache->put($key.'/v'.$value, ob_get_clean()),
                 default => throw new Exception('Unknown strategy: '.$strategy),
             };
         }

--- a/tests/BladeDirectiveTest.php
+++ b/tests/BladeDirectiveTest.php
@@ -94,6 +94,20 @@ class BladeDirectiveTest extends TestCase
         $this->assertTrue($this->cacheManager->has('my-unique-key','tag'));
     }
 
+    public function test_it_handles_versions()
+    {
+        $directive = $this->createNewCacheDirective();
+        $directive->setUp('my-unique-key', ['version' => '1.4.3']);
+        echo "<div>view tag</div>";
+        $directive->tearDown();
+        $options = $directive->getOptions();
+        $this->assertIsArray($options, 'Options should be an array.');
+        $this->assertArrayHasKey('version', $options, 'Options should contain a tags key.');
+        $this->assertIsString($options['version'], 'Tag should be a string.');
+        //test that we set the tag
+        $this->assertTrue($this->cacheManager->has('my-unique-key/v1.4.3'));
+    }
+
     public function test_it_handles_multiple_tags()
     {
         $directive = $this->createNewCacheDirective();


### PR DESCRIPTION
## Description

#### Content Versioning: todo (1% done) 

Uses the version numbers to force cache updates on each release.

```html
@cache('my-unique-key', ['version' => 'v1'])
    <div>view fragment</div>
@endcache
```

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Related Ticket

[*Link to the Redmine ticket.*](https://projects.it-jonction-lab.io/issues/8636)

## Changes

*List the major changes made in this pull request.*

1. Adds the ability to provide an associative array with the key 'version' and a string representing version allowing keys to go stale upon new releases

## Testing
1. Will be tested locally
2. Tests will be written

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
