### PR TITLE
Stale-While-Revalidate

### DIFF
--- a/planForBlade.md
+++ b/planForBlade.md
@@ -1,0 +1,178 @@
+The approach you're describing is heading in the right direction, but the `Blade::render` method doesn't directly exist. Instead, you can compile the Blade template into PHP and then evaluate it.
+
+To make sure the raw content between `@cache` and `@endcache` tags is treated as a Blade template and rendered properly, you can follow these steps:
+
+1. **Capture the raw content in the `@appendCache` directive**.
+2. **Compile and render the Blade template in the background job**.
+
+### Step 1: Update BladeDirective Class
+
+Update the `BladeDirective` class to capture the raw content and handle it appropriately.
+
+```php
+namespace Itjonction\Blockcache\Blade;
+
+use Itjonction\Blockcache\General\CacheManager;
+use Illuminate\Support\Facades\Queue;
+use Itjonction\Blockcache\Jobs\RefreshCacheJob;
+use Illuminate\Support\Facades\Blade;
+
+class BladeDirective
+{
+    protected $cacheManager;
+    protected $key;
+    protected $options;
+    protected $rawContent;
+
+    public function __construct(CacheManager $cacheManager)
+    {
+        $this->cacheManager = $cacheManager;
+    }
+
+    public function setUp($key, $options = [])
+    {
+        $this->key = $key;
+        $this->options = $options;
+        $this->rawContent = '';
+
+        if ($this->cacheManager->has($key)) {
+            // Return the stale content immediately
+            echo $this->cacheManager->get($key);
+
+            if (!empty($options['stale-while-revalidate'])) {
+                // Capture the raw Blade content for refreshing the cache
+                ob_start();
+            }
+
+            return true;
+        }
+
+        // Start output buffering to capture the content
+        ob_start();
+        return false;
+    }
+
+    public function appendRawContent($content)
+    {
+        $this->rawContent .= $content;
+    }
+
+    public function tearDown()
+    {
+        $content = ob_get_clean();
+        echo $content;
+        $this->cacheManager->put($this->key, $content);
+
+        if (!empty($this->options['stale-while-revalidate'])) {
+            // Capture the raw Blade template content
+            Queue::push(new RefreshCacheJob($this->key, $this->rawContent));
+        }
+
+        return $content;
+    }
+}
+```
+
+### Step 2: Update the RefreshCacheJob Class
+
+The job will compile and render the captured Blade content.
+
+```php
+namespace Itjonction\Blockcache\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Itjonction\Blockcache\General\CacheManager;
+use Illuminate\Support\Facades\Blade;
+
+class RefreshCacheJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    protected $key;
+    protected $rawContent;
+
+    public function __construct($key, $rawContent)
+    {
+        $this->key = $key;
+        $this->rawContent = $rawContent;
+    }
+
+    public function handle(CacheManager $cacheManager)
+    {
+        // Compile the raw Blade content into PHP
+        $compiledContent = Blade::compileString($this->rawContent);
+
+        // Evaluate the compiled PHP content
+        ob_start();
+        eval('?>'.$compiledContent);
+        $content = ob_get_clean();
+
+        $cacheManager->put($this->key, $content);
+    }
+}
+```
+
+### Step 3: Update the Service Provider
+
+Make sure the Blade directives are registered correctly.
+
+```php
+namespace Itjonction\Blockcache;
+
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Contracts\Cache\Repository;
+use Itjonction\Blockcache\Blade\BladeDirective;
+
+class BlockCacheServiceProvider extends ServiceProvider
+{
+    public function boot(Kernel $kernel)
+    {
+        if ($this->app->isLocal()) {
+            $kernel->pushMiddleware('Itjonction\Blockcache\FlushViews');
+        }
+
+        Blade::directive('cache', function ($expression) {
+            return "<?php if (! app('Itjonction\Blockcache\Blade\BladeDirective')->setUp{$expression}) : ?>";
+        });
+
+        Blade::directive('appendCache', function ($expression) {
+            return "<?php app('Itjonction\Blockcache\Blade\BladeDirective')->appendRawContent($expression); ?>";
+        });
+
+        Blade::directive('endcache', function () {
+            return "<?php endif; echo app('Itjonction\Blockcache\Blade\BladeDirective')->tearDown() ?>";
+        });
+    }
+
+    public function register()
+    {
+        $this->app->singleton(BladeDirective::class, function ($app) {
+            return new BladeDirective(new CacheManager($app->make(Repository::class)));
+        });
+    }
+}
+```
+
+### Step 4: Use the Blade Directive with Options
+
+Use the `@cache` directive with the `stale-while-revalidate` option and pass the content to `@appendCache`.
+
+```blade
+@cache('my-unique-key', ['stale-while-revalidate' => true])
+@appendCache('<div>view fragment</div>')
+@endcache
+```
+
+### Explanation
+
+1. **setUp Method**: Starts output buffering to capture the content. If `stale-while-revalidate` is enabled, it prepares to capture the raw Blade template content for later use.
+2. **appendRawContent Method**: Appends the raw content to a string property without rendering it.
+3. **tearDown Method**: Stops output buffering and caches the content. If `stale-while-revalidate` is enabled, it queues a job to refresh the cache using the captured raw content.
+4. **RefreshCacheJob Class**: Compiles the captured raw Blade content into PHP and evaluates it to render the content, then updates the cache.
+
+This setup ensures that the raw content between the `@cache` and `@endcache` tags is captured, passed to the background job, and properly rendered to refresh the cache.

--- a/planForLegacy.md
+++ b/planForLegacy.md
@@ -1,0 +1,153 @@
+Implementing `stale-while-revalidate` in your cache manager involves serving stale content while asynchronously refreshing the cache. Here's a step-by-step approach to achieve this in your PHP application.
+
+### Steps to Implement `stale-while-revalidate`
+
+1. **Modify the Cache Manager**: Adjust your cache manager to support `stale-while-revalidate`.
+2. **Use Background Processing**: Use a queue system like Laravel Queues to handle the background cache refresh.
+
+### Step 1: Modify the Cache Manager
+
+First, update your cache manager to handle `stale-while-revalidate` logic.
+
+```php
+namespace Itjonction\Blockcache\General;
+
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Support\Facades\Queue;
+
+class CacheManager
+{
+    protected $cache;
+
+    public function __construct(Repository $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    public function put($key, $fragment)
+    {
+        $key = $this->normalizeCacheKey($key);
+        return $this->cache
+            ->tags('views')
+            ->forever($key, $fragment);
+    }
+
+    public function has($key)
+    {
+        $key = $this->normalizeCacheKey($key);
+        return $this->cache->tags('views')->has($key);
+    }
+
+    public function get($key)
+    {
+        $key = $this->normalizeCacheKey($key);
+        return $this->cache->tags('views')->get($key);
+    }
+
+    public function staleWhileRevalidate($key, $callback)
+    {
+        if ($this->has($key)) {
+            // Return the stale content immediately
+            $content = $this->get($key);
+
+            // Dispatch a job to refresh the cache
+            Queue::push(new RefreshCacheJob($key, $callback));
+
+            return $content;
+        }
+
+        // Cache miss, generate and cache the content
+        $content = $callback();
+        $this->put($key, $content);
+
+        return $content;
+    }
+
+    protected function normalizeCacheKey($key)
+    {
+        if ($key instanceof Model) {
+            return $key->getCacheKey();
+        }
+        return $key;
+    }
+}
+```
+
+### Step 2: Create the Job for Cache Refresh
+
+Create a job class that will handle the background cache refresh.
+
+```php
+namespace Itjonction\Blockcache\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Itjonction\Blockcache\General\CacheManager;
+
+class RefreshCacheJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    protected $key;
+    protected $callback;
+
+    public function __construct($key, $callback)
+    {
+        $this->key = $key;
+        $this->callback = $callback;
+    }
+
+    public function handle(CacheManager $cacheManager)
+    {
+        $content = call_user_func($this->callback);
+        $cacheManager->put($this->key, $content);
+    }
+}
+```
+
+### Step 3: Update Your Application Code
+
+Update your application code to use the new `staleWhileRevalidate` method.
+
+```php
+use Itjonction\Blockcache\General\CacheManager;
+
+$cacheManager = app(CacheManager::class);
+
+$content = $cacheManager->staleWhileRevalidate('unique-key', function () {
+    // Generate the content
+    return "<div>Your HTML content here</div>";
+});
+
+echo $content;
+```
+
+### Step 4: Configure the Queue
+
+Make sure your queue system is configured. You can use different queue drivers supported by Laravel like database, Redis, etc.
+
+1. **Queue Configuration**: Update your `.env` file with the queue driver you want to use, e.g., `database`.
+
+```env
+QUEUE_CONNECTION=database
+```
+
+2. **Queue Table Migration**: If using the database driver, run the following commands to create the necessary tables.
+
+```sh
+php artisan queue:table
+php artisan migrate
+```
+
+3. **Running the Queue Worker**: Start the queue worker to process jobs.
+
+```sh
+php artisan queue:work
+```
+
+### Conclusion
+
+By following these steps, you implement `stale-while-revalidate` caching in your Laravel application. The content is served immediately while a background job refreshes the cache asynchronously. This approach ensures minimal latency for end-users while keeping the cached content up-to-date.


### PR DESCRIPTION
## Description

#### Stale-While-Revalidate

Serves stale content while asynchronously updating the cache.
Use the `@cache` directive with the `stale-while-revalidate` option and pass the content to `@appendCache`.

```blade
@cache('my-unique-key', ['stale-while-revalidate' => true])
@appendCache('<div>view fragment</div>')
@endcache
```

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Related Ticket

[*Link to the Redmine ticket.*](https://projects.it-jonction-lab.io/issues/8636)

## Changes

*List the major changes made in this pull request.*

1. Adds the ability to serve stale content while asynchronously updating the cache.

## Testing
1. Will be tested locally
2. Tests will be written

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
