### PR TITLE
bug(ttl): return fragment when exists

### DIFF
--- a/src/Blade/CacheManager.php
+++ b/src/Blade/CacheManager.php
@@ -17,12 +17,13 @@ class CacheManager implements ManagesCaches
 
     // In CacheManager.php
 
-    public function put($key, $fragment, int | null $ttl = null, string | array $tags = 'views'): string
+    public function remember($key, $fragment, int | null $ttl = null, string | array $tags = 'views'): string
     {
         $key = $this->normalizeCacheKey($key);
         if ($ttl) {
-            $this->cache->tags($tags)->put($key, $fragment, $ttl);
-            return $fragment;
+            $this->cache->tags($tags)->remember($key, $ttl, function () use ($fragment) {
+                return $fragment;
+            });
         }
         return $this->cache->tags($tags)->rememberForever($key, function () use ($fragment) {
             return $fragment;

--- a/src/Blade/CacheManager.php
+++ b/src/Blade/CacheManager.php
@@ -36,6 +36,12 @@ class CacheManager implements ManagesCaches
         return $this->cache->tags($tags)->has($key);
     }
 
+    public function get($key, $tags = 'views'): string
+    {
+        $key = $this->normalizeCacheKey($key);
+        return $this->cache->tags($tags)->get($key);
+    }
+
     protected function normalizeCacheKey($key)
     {
         if($key instanceof Cacheable) {

--- a/src/BladeDirective.php
+++ b/src/BladeDirective.php
@@ -58,7 +58,7 @@ class BladeDirective
         }
         // If no strategy was provided, we'll default to
         if (ob_get_level() > 0) {
-            return $this->cache->put(
+            return $this->cache->remember(
               array_pop($this->keys), ob_get_clean()
             );
         }
@@ -112,9 +112,9 @@ class BladeDirective
     {
         if (ob_get_level() > 0) {
             return match ($strategy) {
-                'tags' => $this->cache->put($key, ob_get_clean(), null, $value),
-                'ttl' => $this->cache->put($key, ob_get_clean(), $this->normalizeTtl($value)),
-                'version' => $this->cache->put($key.'/v'.$value, ob_get_clean()),
+                'tags' => $this->cache->remember($key, ob_get_clean(), null, $value),
+                'ttl' => $this->cache->remember($key, ob_get_clean(), $this->normalizeTtl($value)),
+                'version' => $this->cache->remember($key.'/v'.$value, ob_get_clean()),
                 default => throw new Exception('Unknown strategy: '.$strategy),
             };
         }

--- a/src/Contracts/ManagesCaches.php
+++ b/src/Contracts/ManagesCaches.php
@@ -8,7 +8,7 @@ interface ManagesCaches
 {
     public function __construct(Repository $cache);
 
-    public function put($key, $fragment, int | null $ttl = null, string | array $tags = 'views'): string;
+    public function remember($key, $fragment, int | null $ttl = null, string | array $tags = 'views'): string;
 
     public function has($key, $tags = null): bool;
 }

--- a/tests/BladeCacheManagerTest.php
+++ b/tests/BladeCacheManagerTest.php
@@ -14,7 +14,7 @@ class BladeCacheManagerTest extends TestCase
         );
         $cacheManager = new CacheManager($cache);
 
-        $cacheManager->put($post, '<div>view fragment</div>');
+        $cacheManager->remember($post, '<div>view fragment</div>');
         $this->assertTrue($cacheManager->has($post));
     }
     function test_it_caches_the_given_key_from_key()
@@ -25,7 +25,7 @@ class BladeCacheManagerTest extends TestCase
         );
         $cacheManager = new CacheManager($cache);
 
-        $cacheManager->put($post->getCacheKey(), '<div>view fragment</div>');
+        $cacheManager->remember($post->getCacheKey(), '<div>view fragment</div>');
         $this->assertTrue($cacheManager->has($post->getCacheKey()));
     }
     function test_it_caches_the_given_key_from_string()
@@ -35,7 +35,7 @@ class BladeCacheManagerTest extends TestCase
         );
         $cacheManager = new CacheManager($cache);
 
-        $cacheManager->put('arbitrary-string', '<div>view fragment</div>');
+        $cacheManager->remember('arbitrary-string', '<div>view fragment</div>');
         $this->assertTrue($cacheManager->has('arbitrary-string'));
     }
 }

--- a/tests/BladeCacheManagerTest.php
+++ b/tests/BladeCacheManagerTest.php
@@ -38,4 +38,51 @@ class BladeCacheManagerTest extends TestCase
         $cacheManager->remember('arbitrary-string', '<div>view fragment</div>');
         $this->assertTrue($cacheManager->has('arbitrary-string'));
     }
+
+    public function test_it_remembers_fragment_with_ttl()
+    {
+        $cache = new Repository(
+          new ArrayStore
+        );
+        $cacheManager = new CacheManager($cache);
+
+        $key = 'test-key';
+        $fragment = '<div>view fragment with ttl</div>';
+        $ttl = 60; // 1 minute
+
+        // Call remember method to cache the fragment with a TTL
+        $cachedFragment = $cacheManager->remember($key, $fragment, $ttl);
+
+        // Check that the fragment is returned correctly
+        $this->assertEquals($fragment, $cachedFragment, 'The returned fragment should match the cached fragment.');
+
+        // Retrieve the cached fragment from the cache store
+        $retrievedFragment = $cacheManager->get($key);
+
+        // Check that the cached fragment is the same as the original fragment
+        $this->assertEquals($fragment, $retrievedFragment, 'The fragment stored in the cache should match the original fragment.');
+    }
+
+    public function test_it_remembers_fragment_forever_when_no_ttl()
+    {
+        $cache = new Repository(
+          new ArrayStore
+        );
+        $cacheManager = new CacheManager($cache);
+
+        $key = 'test-key-forever';
+        $fragment = '<div>view fragment forever</div>';
+
+        // Call remember method to cache the fragment forever
+        $cachedFragment = $cacheManager->remember($key, $fragment);
+
+        // Check that the fragment is returned correctly
+        $this->assertEquals($fragment, $cachedFragment, 'The returned fragment should match the cached fragment.');
+
+        // Retrieve the cached fragment from the cache store
+        $retrievedFragment = $cacheManager->get($key);
+
+        // Check that the cached fragment is the same as the original fragment
+        $this->assertEquals($fragment, $retrievedFragment, 'The fragment stored in the cache should match the original fragment.');
+    }
 }

--- a/tests/GeneralCacheManagerTest.php
+++ b/tests/GeneralCacheManagerTest.php
@@ -14,7 +14,7 @@ class GeneralCacheManagerTest extends TestCase
         );
         $cacheManager = new CacheManager($cache);
 
-        $cacheManager->put($post, '<div>view fragment</div>');
+        $cacheManager->remember($post, '<div>view fragment</div>');
         $this->assertTrue($cacheManager->has($post));
     }
     function test_it_caches_the_given_key_from_key()
@@ -25,7 +25,7 @@ class GeneralCacheManagerTest extends TestCase
         );
         $cacheManager = new CacheManager($cache);
 
-        $cacheManager->put($post->getCacheKey(), '<div>view fragment</div>');
+        $cacheManager->remember($post->getCacheKey(), '<div>view fragment</div>');
         $this->assertTrue($cacheManager->has($post->getCacheKey()));
     }
     function test_it_caches_the_given_key_from_string()
@@ -35,7 +35,7 @@ class GeneralCacheManagerTest extends TestCase
         );
         $cacheManager = new CacheManager($cache);
 
-        $cacheManager->put('arbitrary-string', '<div>view fragment</div>');
+        $cacheManager->remember('arbitrary-string', '<div>view fragment</div>');
         $this->assertTrue($cacheManager->has('arbitrary-string'));
     }
 

--- a/tests/GeneralCacheManagerTest.php
+++ b/tests/GeneralCacheManagerTest.php
@@ -55,4 +55,47 @@ class GeneralCacheManagerTest extends TestCase
         $this->assertTrue($cacheManager->has('arbitrary-string'));
         $this->assertEquals('<div>view fragment</div>', $output);
     }
+
+    public function test_it_remembers_fragment_with_ttl()
+    {
+        $cache = new Repository(
+          new ArrayStore
+        );
+        $cacheManager = new CacheManager($cache);
+
+        $key = 'test-key';
+        $fragment = '<div>view fragment with ttl</div>';
+        $ttl = 60; // 1 minute
+
+        // Call remember method to cache the fragment with a TTL
+        $cachedFragment = $cacheManager->remember($key, $fragment, $ttl);
+
+        // Check that the fragment is returned correctly
+        $this->assertEquals($fragment, $cachedFragment, 'The returned fragment should match the cached fragment.');
+
+        // Retrieve the cached fragment from the cache store
+        $retrievedFragment = $cacheManager->get($key);
+        $this->assertEquals($fragment, $retrievedFragment, 'The retrieved fragment should match the cached fragment.');
+    }
+
+    public function test_it_remembers_fragment_forever_when_no_ttl()
+    {
+        $cache = new Repository(
+          new ArrayStore
+        );
+        $cacheManager = new CacheManager($cache);
+
+        $key = 'test-key';
+        $fragment = '<div>view fragment forever</div>';
+
+        // Call remember method to cache the fragment forever
+        $cachedFragment = $cacheManager->remember($key, $fragment);
+
+        // Check that the fragment is returned correctly
+        $this->assertEquals($fragment, $cachedFragment, 'The returned fragment should match the cached fragment.');
+
+        // Retrieve the cached fragment from the cache store
+        $retrievedFragment = $cacheManager->get($key);
+        $this->assertEquals($fragment, $retrievedFragment, 'The retrieved fragment should match the cached fragment.');
+    }
 }


### PR DESCRIPTION
## Description

When we used the TTL strategy the solution wasn't returning the fragment when it was in the cache.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

New test added to prove that it does return when it exists.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
